### PR TITLE
Relax the version guard for InSilicoSeq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     py_modules=['idseq-bench'],
     python_requires='>=3.6, <4',
     install_requires=[
-        'InSilicoSeq==1.4.2',
+        'InSilicoSeq>=1.4.2',
         'ncbi-acc-download',
         'numpy',
         'scikit-learn',


### PR DESCRIPTION
Hi,

InSilicoSeq latest version (1.4.8 for now) is works well with this module.

I am proposing the patch for relaxing the version guard for InSilicoSeq.

Thank you!